### PR TITLE
Add Windows build workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,45 @@
+name: Windows Binaries
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: [x64, arm64]
+        include:
+          - arch: x64
+            devcmd_arch: amd64
+            preset: x64-windows-msvc-release
+          - arch: arm64
+            devcmd_arch: amd64_arm64
+            preset: arm64-windows-llvm-release
+            extra_flags: "-DGGML_OPENMP=OFF"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.devcmd_arch }}
+
+      - name: Configure
+        run: cmake --preset ${{ matrix.preset }} ${{ matrix.extra_flags }}
+
+      - name: Build
+        run: cmake --build build-${{ matrix.preset }} --parallel
+
+      - name: Install
+        run: cmake --install build-${{ matrix.preset }} --prefix install
+
+      - name: Package artifacts
+        run: Compress-Archive -Path install/* -DestinationPath ${{ matrix.arch }}-binaries.zip
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: windows-${{ matrix.arch }}-binaries
+          path: ${{ matrix.arch }}-binaries.zip


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build Windows binaries for x64 and arm64

## Testing
- `pre-commit run check-yaml --files .github/workflows/windows-build.yml`
- `pre-commit run trailing-whitespace --files .github/workflows/windows-build.yml`
- `pre-commit run end-of-file-fixer --files .github/workflows/windows-build.yml`
- `pre-commit run check-added-large-files --files .github/workflows/windows-build.yml`


------
https://chatgpt.com/codex/tasks/task_b_688b5f2c7c288325b17af50393e41d1f