### PR TITLE
Fix build error for Windows ARM64

### DIFF
--- a/cmake/arm64-windows-llvm.cmake
+++ b/cmake/arm64-windows-llvm.cmake
@@ -9,7 +9,7 @@ set( CMAKE_CXX_COMPILER  clang++ )
 set( CMAKE_C_COMPILER_TARGET   ${target} )
 set( CMAKE_CXX_COMPILER_TARGET ${target} )
 
-set( arch_c_flags "-march=armv8.7-a -mattr=+fullfp16 -fvectorize -ffp-model=fast -fno-finite-math-only" )
+set( arch_c_flags "-march=armv8.7-a -Xclang -target-feature -Xclang +fullfp16 -fvectorize -ffp-model=fast -fno-finite-math-only" )
 set( warn_c_flags "-Wno-format -Wno-unused-variable -Wno-unused-function -Wno-gnu-zero-variadic-macro-arguments" )
 
 set( CMAKE_C_FLAGS_INIT   "${arch_c_flags} ${warn_c_flags}" )


### PR DESCRIPTION
## Summary
- enable full ARMv8.7 FP16 support when using the LLVM toolchain for Windows

## Testing
- `pre-commit` (with flake8 skipped due to dependency conflict)
- `cmake -S . -B build`
- `cmake --build build -j 2` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_688b64928d188325beec0a4396c29eb0