### PR TITLE
Fix SSE includes for Windows ARM build

### DIFF
--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -34,14 +34,20 @@
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data
 #include <intrin.h>
+#if defined(_M_IX86) || defined(_M_X64)
 #include <ammintrin.h>
 #include <nmmintrin.h>
 #include <immintrin.h>
+#endif
 #include <stdlib.h>
 inline int popcount(uint8_t x) { return __popcnt(x); }
 inline int popcount(uint16_t x) { return __popcnt(x); }
 inline int popcount(uint32_t x) { return __popcnt(x); }
+#if defined(_M_IX86) || defined(_M_X64)
 inline int popcount(uint64_t x) { return _mm_popcnt_u64(x); }
+#else
+inline int popcount(uint64_t x) { return __popcnt64(x); }
+#endif
 #else
 constexpr int popcount(uint8_t x) { return __builtin_popcount(x); }
 constexpr int popcount(uint16_t x) { return __builtin_popcount(x); }


### PR DESCRIPTION
## Summary
- guard SSE header inclusion in `iqk_quantize.cpp`
- choose `__popcnt64` when SSE isn't available
- verified `ggml` library builds

## Testing
- `cmake -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target ggml`


------
https://chatgpt.com/codex/tasks/task_b_688b6b77a230832594287fdda2cc5720