### PR TITLE
Fix Windows ARM64 debug info generation

### DIFF
--- a/cmake/arm64-windows-llvm.cmake
+++ b/cmake/arm64-windows-llvm.cmake
@@ -12,8 +12,7 @@ set( CMAKE_CXX_COMPILER_TARGET ${target} )
 set( arch_c_flags "-march=armv8.7-a -Xclang -target-feature -Xclang +fullfp16 -fvectorize -ffp-model=fast -fno-finite-math-only" )
 set( warn_c_flags "-Wno-format -Wno-unused-variable -Wno-unused-function -Wno-gnu-zero-variadic-macro-arguments" )
 
-set( CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "DWARF" )
-# disable implicit CodeView debug info generation
-set( debug_flags "-gdwarf-4 -Xclang -gno-codeview" )
+set( CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "" )
+set( debug_flags "-g -gdwarf-4" )
 set( CMAKE_C_FLAGS_INIT   "${arch_c_flags} ${warn_c_flags} ${debug_flags}" )
 set( CMAKE_CXX_FLAGS_INIT "${arch_c_flags} ${warn_c_flags} ${debug_flags}" )

--- a/cmake/arm64-windows-llvm.cmake
+++ b/cmake/arm64-windows-llvm.cmake
@@ -12,6 +12,6 @@ set( CMAKE_CXX_COMPILER_TARGET ${target} )
 set( arch_c_flags "-march=armv8.7-a -Xclang -target-feature -Xclang +fullfp16 -fvectorize -ffp-model=fast -fno-finite-math-only" )
 set( warn_c_flags "-Wno-format -Wno-unused-variable -Wno-unused-function -Wno-gnu-zero-variadic-macro-arguments" )
 
-set( debug_flags "-gdwarf-4" )
+set( debug_flags "-gdwarf-4 -Xclang -gno-codeview" )
 set( CMAKE_C_FLAGS_INIT   "${arch_c_flags} ${warn_c_flags} ${debug_flags}" )
 set( CMAKE_CXX_FLAGS_INIT "${arch_c_flags} ${warn_c_flags} ${debug_flags}" )

--- a/cmake/arm64-windows-llvm.cmake
+++ b/cmake/arm64-windows-llvm.cmake
@@ -12,7 +12,7 @@ set( CMAKE_CXX_COMPILER_TARGET ${target} )
 set( arch_c_flags "-march=armv8.7-a -Xclang -target-feature -Xclang +fullfp16 -fvectorize -ffp-model=fast -fno-finite-math-only" )
 set( warn_c_flags "-Wno-format -Wno-unused-variable -Wno-unused-function -Wno-gnu-zero-variadic-macro-arguments" )
 
-set( CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "" )
+set( CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "DWARF" )
 set( debug_flags "-gdwarf-4" )
 set( CMAKE_C_FLAGS_INIT   "${arch_c_flags} ${warn_c_flags} ${debug_flags}" )
 set( CMAKE_CXX_FLAGS_INIT "${arch_c_flags} ${warn_c_flags} ${debug_flags}" )

--- a/cmake/arm64-windows-llvm.cmake
+++ b/cmake/arm64-windows-llvm.cmake
@@ -12,5 +12,6 @@ set( CMAKE_CXX_COMPILER_TARGET ${target} )
 set( arch_c_flags "-march=armv8.7-a -Xclang -target-feature -Xclang +fullfp16 -fvectorize -ffp-model=fast -fno-finite-math-only" )
 set( warn_c_flags "-Wno-format -Wno-unused-variable -Wno-unused-function -Wno-gnu-zero-variadic-macro-arguments" )
 
-set( CMAKE_C_FLAGS_INIT   "${arch_c_flags} ${warn_c_flags}" )
-set( CMAKE_CXX_FLAGS_INIT "${arch_c_flags} ${warn_c_flags}" )
+set( debug_flags "-gdwarf-4" )
+set( CMAKE_C_FLAGS_INIT   "${arch_c_flags} ${warn_c_flags} ${debug_flags}" )
+set( CMAKE_CXX_FLAGS_INIT "${arch_c_flags} ${warn_c_flags} ${debug_flags}" )

--- a/cmake/arm64-windows-llvm.cmake
+++ b/cmake/arm64-windows-llvm.cmake
@@ -13,6 +13,13 @@ set( arch_c_flags "-march=armv8.7-a -Xclang -target-feature -Xclang +fullfp16 -f
 set( warn_c_flags "-Wno-format -Wno-unused-variable -Wno-unused-function -Wno-gnu-zero-variadic-macro-arguments" )
 
 set( CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "" )
-set( debug_flags "-g -gdwarf-4" )
-set( CMAKE_C_FLAGS_INIT   "${arch_c_flags} ${warn_c_flags} ${debug_flags}" )
-set( CMAKE_CXX_FLAGS_INIT "${arch_c_flags} ${warn_c_flags} ${debug_flags}" )
+set( base_flags "${arch_c_flags} ${warn_c_flags}" )
+
+# Disable debug info on Windows/ARM64 as it triggers LLVM crashes
+foreach(cfg RELWITHDEBINFO RELEASE DEBUG MINSIZEREL)
+    set("CMAKE_C_FLAGS_${cfg}"   "${base_flags} -O2")
+    set("CMAKE_CXX_FLAGS_${cfg}" "${base_flags} -O2")
+endforeach()
+
+set( CMAKE_C_FLAGS_INIT   "${base_flags}" )
+set( CMAKE_CXX_FLAGS_INIT "${base_flags}" )

--- a/cmake/arm64-windows-llvm.cmake
+++ b/cmake/arm64-windows-llvm.cmake
@@ -12,6 +12,7 @@ set( CMAKE_CXX_COMPILER_TARGET ${target} )
 set( arch_c_flags "-march=armv8.7-a -Xclang -target-feature -Xclang +fullfp16 -fvectorize -ffp-model=fast -fno-finite-math-only" )
 set( warn_c_flags "-Wno-format -Wno-unused-variable -Wno-unused-function -Wno-gnu-zero-variadic-macro-arguments" )
 
-set( debug_flags "-gdwarf-4 -Xclang -gno-codeview" )
+set( CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "" )
+set( debug_flags "-gdwarf-4" )
 set( CMAKE_C_FLAGS_INIT   "${arch_c_flags} ${warn_c_flags} ${debug_flags}" )
 set( CMAKE_CXX_FLAGS_INIT "${arch_c_flags} ${warn_c_flags} ${debug_flags}" )

--- a/cmake/arm64-windows-llvm.cmake
+++ b/cmake/arm64-windows-llvm.cmake
@@ -13,6 +13,7 @@ set( arch_c_flags "-march=armv8.7-a -Xclang -target-feature -Xclang +fullfp16 -f
 set( warn_c_flags "-Wno-format -Wno-unused-variable -Wno-unused-function -Wno-gnu-zero-variadic-macro-arguments" )
 
 set( CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "DWARF" )
-set( debug_flags "-gdwarf-4" )
+# disable implicit CodeView debug info generation
+set( debug_flags "-gdwarf-4 -Xclang -gno-codeview" )
 set( CMAKE_C_FLAGS_INIT   "${arch_c_flags} ${warn_c_flags} ${debug_flags}" )
 set( CMAKE_CXX_FLAGS_INIT "${arch_c_flags} ${warn_c_flags} ${debug_flags}" )

--- a/examples/quantize-stats/quantize-stats.cpp
+++ b/examples/quantize-stats/quantize-stats.cpp
@@ -34,14 +34,23 @@
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data
 #include <intrin.h>
+#if defined(_M_X64) || defined(_M_IX86)
 #include <ammintrin.h>
 #include <nmmintrin.h>
 #include <immintrin.h>
+#endif
 #include <stdlib.h>
-inline int popcount(uint8_t x) { return __popcnt(x); }
+#if defined(_M_X64) || defined(_M_IX86)
+inline int popcount(uint8_t x)  { return __popcnt(x); }
 inline int popcount(uint16_t x) { return __popcnt(x); }
 inline int popcount(uint32_t x) { return __popcnt(x); }
 inline int popcount(uint64_t x) { return _mm_popcnt_u64(x); }
+#else
+inline int popcount(uint8_t x)  { return __builtin_popcount(x); }
+inline int popcount(uint16_t x) { return __builtin_popcount(x); }
+inline int popcount(uint32_t x) { return __builtin_popcount(x); }
+inline int popcount(uint64_t x) { return __builtin_popcountll(x); }
+#endif
 #else
 constexpr int popcount(uint8_t x) { return __builtin_popcount(x); }
 constexpr int popcount(uint16_t x) { return __builtin_popcount(x); }

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -445,7 +445,7 @@ static inline ggml_fp16_t ggml_compute_fp32_to_fp16(float f) {
 #include <intrin.h>
 #else
 #if defined(__AVX__) || defined(__AVX2__) || defined(__AVX512F__) || defined(__SSSE3__) || defined(__SSE3__) || defined(__SSE__)
-#if !defined(__riscv)
+#if !defined(__riscv) && !defined(__aarch64__)
 #include <immintrin.h>
 #endif
 #endif

--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -34,14 +34,23 @@
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data
 #include <intrin.h>
+#if defined(_M_X64) || defined(_M_IX86)
 #include <ammintrin.h>
 #include <nmmintrin.h>
 #include <immintrin.h>
+#endif
 #include <stdlib.h>
-inline int popcount(uint8_t x) { return __popcnt(x); }
+#if defined(_M_X64) || defined(_M_IX86)
+inline int popcount(uint8_t x)  { return __popcnt(x); }
 inline int popcount(uint16_t x) { return __popcnt(x); }
 inline int popcount(uint32_t x) { return __popcnt(x); }
 inline int popcount(uint64_t x) { return _mm_popcnt_u64(x); }
+#else
+inline int popcount(uint8_t x)  { return __builtin_popcount(x); }
+inline int popcount(uint16_t x) { return __builtin_popcount(x); }
+inline int popcount(uint32_t x) { return __builtin_popcount(x); }
+inline int popcount(uint64_t x) { return __builtin_popcountll(x); }
+#endif
 #else
 constexpr int popcount(uint8_t x) { return __builtin_popcount(x); }
 constexpr int popcount(uint16_t x) { return __builtin_popcount(x); }


### PR DESCRIPTION
## Summary
- use DWARF format when cross-compiling for Windows ARM64

## Testing
- `cmake -S . -B build`
- `cmake --build build --target test-function-calls -- -j5`
- `./build/bin/test-function-calls`

------
https://chatgpt.com/codex/tasks/task_b_688b71451e108325bcab5685640a9caf