### PR TITLE
Fix Windows ARM64 debug flags

### DIFF
--- a/cmake/arm64-windows-llvm.cmake
+++ b/cmake/arm64-windows-llvm.cmake
@@ -15,7 +15,9 @@ set( warn_c_flags "-Wno-format -Wno-unused-variable -Wno-unused-function -Wno-gn
 set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "")
 
 set(base_flags "${arch_c_flags} ${warn_c_flags}")
-set(debug_flags "-g -gdwarf-4")
+# Disable CodeView generation as it causes crashes when cross compiling with
+# clang-cl; instead rely solely on DWARF debug information.
+set(debug_flags "-g -gdwarf-4 -Xclang -gno-codeview")
 
 set(CMAKE_C_FLAGS_INIT   "${base_flags}")
 set(CMAKE_CXX_FLAGS_INIT "${base_flags}")

--- a/cmake/arm64-windows-llvm.cmake
+++ b/cmake/arm64-windows-llvm.cmake
@@ -12,5 +12,19 @@ set( CMAKE_CXX_COMPILER_TARGET ${target} )
 set( arch_c_flags "-march=armv8.7-a -Xclang -target-feature -Xclang +fullfp16 -fvectorize -ffp-model=fast -fno-finite-math-only" )
 set( warn_c_flags "-Wno-format -Wno-unused-variable -Wno-unused-function -Wno-gnu-zero-variadic-macro-arguments" )
 
-set( CMAKE_C_FLAGS_INIT   "${arch_c_flags} ${warn_c_flags}" )
-set( CMAKE_CXX_FLAGS_INIT "${arch_c_flags} ${warn_c_flags}" )
+set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "")
+
+set(base_flags "${arch_c_flags} ${warn_c_flags}")
+set(debug_flags "-g -gdwarf-4")
+
+set(CMAKE_C_FLAGS_INIT   "${base_flags}")
+set(CMAKE_CXX_FLAGS_INIT "${base_flags}")
+
+set(CMAKE_C_FLAGS_DEBUG_INIT            "${debug_flags}")
+set(CMAKE_CXX_FLAGS_DEBUG_INIT          "${debug_flags}")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO_INIT   "-O2 -DNDEBUG ${debug_flags}")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "-O2 -DNDEBUG ${debug_flags}")
+set(CMAKE_C_FLAGS_RELEASE_INIT          "-O3 -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE_INIT        "-O3 -DNDEBUG")
+set(CMAKE_C_FLAGS_MINSIZEREL_INIT       "-Os -DNDEBUG")
+set(CMAKE_CXX_FLAGS_MINSIZEREL_INIT     "-Os -DNDEBUG")

--- a/examples/quantize-stats/quantize-stats.cpp
+++ b/examples/quantize-stats/quantize-stats.cpp
@@ -34,14 +34,23 @@
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data
 #include <intrin.h>
+#if defined(_M_X64) || defined(_M_IX86)
 #include <ammintrin.h>
 #include <nmmintrin.h>
 #include <immintrin.h>
+#endif
 #include <stdlib.h>
-inline int popcount(uint8_t x) { return __popcnt(x); }
+#if defined(_M_X64) || defined(_M_IX86)
+inline int popcount(uint8_t x)  { return __popcnt(x); }
 inline int popcount(uint16_t x) { return __popcnt(x); }
 inline int popcount(uint32_t x) { return __popcnt(x); }
 inline int popcount(uint64_t x) { return _mm_popcnt_u64(x); }
+#else
+inline int popcount(uint8_t x)  { return __builtin_popcount(x); }
+inline int popcount(uint16_t x) { return __builtin_popcount(x); }
+inline int popcount(uint32_t x) { return __builtin_popcount(x); }
+inline int popcount(uint64_t x) { return __builtin_popcountll(x); }
+#endif
 #else
 constexpr int popcount(uint8_t x) { return __builtin_popcount(x); }
 constexpr int popcount(uint16_t x) { return __builtin_popcount(x); }

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -445,7 +445,7 @@ static inline ggml_fp16_t ggml_compute_fp32_to_fp16(float f) {
 #include <intrin.h>
 #else
 #if defined(__AVX__) || defined(__AVX2__) || defined(__AVX512F__) || defined(__SSSE3__) || defined(__SSE3__) || defined(__SSE__)
-#if !defined(__riscv)
+#if !defined(__riscv) && !defined(__aarch64__)
 #include <immintrin.h>
 #endif
 #endif

--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -34,14 +34,23 @@
 #if defined(_MSC_VER)
 #pragma warning(disable: 4244 4267) // possible loss of data
 #include <intrin.h>
+#if defined(_M_X64) || defined(_M_IX86)
 #include <ammintrin.h>
 #include <nmmintrin.h>
 #include <immintrin.h>
+#endif
 #include <stdlib.h>
-inline int popcount(uint8_t x) { return __popcnt(x); }
+#if defined(_M_X64) || defined(_M_IX86)
+inline int popcount(uint8_t x)  { return __popcnt(x); }
 inline int popcount(uint16_t x) { return __popcnt(x); }
 inline int popcount(uint32_t x) { return __popcnt(x); }
 inline int popcount(uint64_t x) { return _mm_popcnt_u64(x); }
+#else
+inline int popcount(uint8_t x)  { return __builtin_popcount(x); }
+inline int popcount(uint16_t x) { return __builtin_popcount(x); }
+inline int popcount(uint32_t x) { return __builtin_popcount(x); }
+inline int popcount(uint64_t x) { return __builtin_popcountll(x); }
+#endif
 #else
 constexpr int popcount(uint8_t x) { return __builtin_popcount(x); }
 constexpr int popcount(uint16_t x) { return __builtin_popcount(x); }


### PR DESCRIPTION
## Summary
- avoid MSVC CodeView when cross compiling for Windows ARM64
- set build type flags explicitly for the LLVM toolchain
- already guard SSE intrinsics on non‑x86 builds

## Testing
- `cmake -S . -B build`
- `cmake --build build --target test-function-calls -- -j$(nproc)`
- `./build/bin/test-function-calls`


------
https://chatgpt.com/codex/tasks/task_b_688b71451e108325bcab5685640a9caf