### PR TITLE
Fix CUDA compile errors in ggml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ endif
 MK_CPPFLAGS  = -Iggml/include -Iggml/src -Iinclude -Isrc -Icommon -I.
 MK_CFLAGS    = -std=c11   -fPIC
 MK_CXXFLAGS  = -std=c++17 -fPIC
-MK_NVCCFLAGS = -std=c++17
+MK_NVCCFLAGS = -std=c++17 -extended-lambda
 
 ifdef LLAMA_NO_CCACHE
 GGML_NO_CCACHE := 1

--- a/ggml/src/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda.cu
@@ -58,6 +58,10 @@
 
 #define IK_PRINT_TIMING 0
 
+#ifndef GGML_CUDA_MIN_BATCH_OFFLOAD
+#define GGML_CUDA_MIN_BATCH_OFFLOAD 32
+#endif
+
 static_assert(sizeof(half) == sizeof(ggml_fp16_t), "wrong fp16 size");
 
 static void ggml_cuda_default_log_callback(enum ggml_log_level level, const char * msg, void * user_data) {

--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -355,7 +355,7 @@ float __device__ __forceinline__ trellis_next(uint32_t& val) {
     const half * h = (const half *)&s;
     val = ka*val + kb;
     s = (val & kmask) ^ km32;
-    return (float)(h[0]+h[1]);
+    return __half2float(h[0]) + __half2float(h[1]);
 }
 
 template<typename dst_t>

--- a/ggml/src/ggml-cuda/dmmv.cu
+++ b/ggml/src/ggml-cuda/dmmv.cu
@@ -34,10 +34,18 @@ static __device__ __forceinline__ void trellis_accum(uint32_t& val1, uint32_t& v
     bdot1 = __hfma2(y[ 0], {h[0]+h[1], h[2]+h[3]}, bdot1);
     bdot2 = __hfma2(y[64], {h[4]+h[5], h[6]+h[7]}, bdot2);
 #else
-    bdot1.x += y[ 0].x * (float)(h[0] + h[1]);
-    bdot1.y += y[ 0].y * (float)(h[2] + h[3]);
-    bdot2.x += y[64].x * (float)(h[4] + h[5]);
-    bdot2.y += y[64].y * (float)(h[6] + h[7]);
+    const float h0 = __half2float(h[0]);
+    const float h1 = __half2float(h[1]);
+    const float h2 = __half2float(h[2]);
+    const float h3 = __half2float(h[3]);
+    const float h4 = __half2float(h[4]);
+    const float h5 = __half2float(h[5]);
+    const float h6 = __half2float(h[6]);
+    const float h7 = __half2float(h[7]);
+    bdot1.x += y[ 0].x * (h0 + h1);
+    bdot1.y += y[ 0].y * (h2 + h3);
+    bdot2.x += y[64].x * (h4 + h5);
+    bdot2.y += y[64].y * (h6 + h7);
 #endif
 }
 
@@ -56,10 +64,14 @@ static __device__ __forceinline__ void trellis_accum_abs(uint8_t signs1, uint8_t
     bdot1 = __hfma2(y[ 0], h1, bdot1);
     bdot2 = __hfma2(y[64], h2, bdot2);
 #else
-    bdot1.x += y[ 0].x * fabsf((float)(h[0] + h[1])) * (signs1 & mask1 ? -1 : 1);
-    bdot1.y += y[ 0].y * fabsf((float)(h[2] + h[3])) * (signs2 & mask1 ? -1 : 1);
-    bdot2.x += y[64].x * fabsf((float)(h[4] + h[5])) * (signs1 & mask2 ? -1 : 1);
-    bdot2.y += y[64].y * fabsf((float)(h[6] + h[7])) * (signs2 & mask2 ? -1 : 1);
+    const float h00 = __half2float(h[0]) + __half2float(h[1]);
+    const float h01 = __half2float(h[2]) + __half2float(h[3]);
+    const float h10 = __half2float(h[4]) + __half2float(h[5]);
+    const float h11 = __half2float(h[6]) + __half2float(h[7]);
+    bdot1.x += y[ 0].x * fabsf(h00) * (signs1 & mask1 ? -1 : 1);
+    bdot1.y += y[ 0].y * fabsf(h01) * (signs2 & mask1 ? -1 : 1);
+    bdot2.x += y[64].x * fabsf(h10) * (signs1 & mask2 ? -1 : 1);
+    bdot2.y += y[64].y * fabsf(h11) * (signs2 & mask2 ? -1 : 1);
 #endif
 }
 


### PR DESCRIPTION
## Summary
- define default GGML_CUDA_MIN_BATCH_OFFLOAD for non-CMake builds
- enable extended lambda support for CUDA compilation
- fix half-to-float conversions in CUDA kernels

## Testing
- `nvcc -std=c++17 -extended-lambda -O3 -Iggml/include -Iggml/src -Iggml/src/ggml-cuda -Iinclude -Isrc -Icommon -I. -D_XOPEN_SOURCE=600 -D_GNU_SOURCE -DNDEBUG -DGGML_USE_CUDA -c ggml/src/ggml-cuda/dmmv.cu -o /tmp/dmmv.o` *(fails: nvcc not found)*


------
https://chatgpt.com/codex/tasks/task_b_688dafc2c2dc8325a1921a28ca6676e8