### PR TITLE
Avoid -march=native for cross-architecture builds

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -50,7 +50,13 @@ else()
     set(GGML_BLAS_VENDOR_DEFAULT "Generic")
 endif()
 
-if (CMAKE_CROSSCOMPILING)
+# Disable native builds when cross-compiling or when the target processor
+# differs from the host processor.  In some environments (e.g. Windows
+# arm64 cross-builds using clang), CMake does not set the
+# CMAKE_CROSSCOMPILING flag even though the target architecture is
+# different.  Passing `-march=native` in such cases results in compiler
+# errors, so explicitly check the processor as well.
+if (CMAKE_CROSSCOMPILING OR NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL CMAKE_HOST_SYSTEM_PROCESSOR))
     set(GGML_NATIVE_DEFAULT OFF)
 else()
     set(GGML_NATIVE_DEFAULT ON)

--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -58,8 +58,17 @@ endif()
 # errors, so explicitly check the processor as well.
 if (CMAKE_CROSSCOMPILING OR NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL CMAKE_HOST_SYSTEM_PROCESSOR))
     set(GGML_NATIVE_DEFAULT OFF)
+    set(GGML_CROSS_DIFFERENT_ARCH ON)
 else()
     set(GGML_NATIVE_DEFAULT ON)
+    set(GGML_CROSS_DIFFERENT_ARCH OFF)
+endif()
+
+# When cross-compiling with clang for Windows the default CodeView debug
+# info can trigger LLVM backend crashes.  In that case, prefer DWARF
+# debug info instead.
+if (GGML_CROSS_DIFFERENT_ARCH AND WIN32 AND CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    add_compile_options(-gdwarf-4)
 endif()
 
 # general

--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -69,6 +69,10 @@ endif()
 # debug info instead.
 if (GGML_CROSS_DIFFERENT_ARCH AND WIN32 AND CMAKE_C_COMPILER_ID STREQUAL "Clang")
     add_compile_options(-gdwarf-4)
+    foreach(lang C CXX)
+        string(REGEX REPLACE "-Xclang[ ]+-gcodeview" "" CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS}")
+        set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS}" CACHE STRING "" FORCE)
+    endforeach()
 endif()
 
 # general

--- a/ggml/src/iqk/iqk_quantize.cpp
+++ b/ggml/src/iqk/iqk_quantize.cpp
@@ -31,7 +31,7 @@
 #include <unordered_map>
 #include <string>
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
 #pragma warning(disable: 4244 4267) // possible loss of data
 #include <intrin.h>
 #include <ammintrin.h>


### PR DESCRIPTION
## Summary
- avoid passing `-march=native` when the build target CPU differs from the host

## Testing
- `pre-commit run --files ggml/CMakeLists.txt` *(fails: ResolutionImpossible: flake8-no-print conflicts with flake8)*
- `cmake -B build`

------
https://chatgpt.com/codex/tasks/task_b_688db0b99cc08325805cb3c238f5b0b4