### PR TITLE
ci: build and push Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,61 @@
+name: Build and push Docker images
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - dockerfile: .devops/full.Dockerfile
+            tag: full
+          - dockerfile: .devops/full-cuda.Dockerfile
+            tag: full-cuda
+          - dockerfile: .devops/full-rocm.Dockerfile
+            tag: full-rocm
+          - dockerfile: .devops/llama-cli.Dockerfile
+            tag: llama-cli
+          - dockerfile: .devops/llama-cli-cuda.Dockerfile
+            tag: llama-cli-cuda
+          - dockerfile: .devops/llama-cli-intel.Dockerfile
+            tag: llama-cli-intel
+          - dockerfile: .devops/llama-cli-rocm.Dockerfile
+            tag: llama-cli-rocm
+          - dockerfile: .devops/llama-cli-vulkan.Dockerfile
+            tag: llama-cli-vulkan
+          - dockerfile: .devops/llama-server.Dockerfile
+            tag: llama-server
+          - dockerfile: .devops/llama-server-cuda.Dockerfile
+            tag: llama-server-cuda
+          - dockerfile: .devops/llama-server-intel.Dockerfile
+            tag: llama-server-intel
+          - dockerfile: .devops/llama-server-rocm.Dockerfile
+            tag: llama-server-rocm
+          - dockerfile: .devops/llama-server-vulkan.Dockerfile
+            tag: llama-server-vulkan
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ matrix.tag }}


### PR DESCRIPTION
## Summary
- build and publish Docker images from the `.devops` directory to GHCR when pushing to `main`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_688db3de5cb08325922872b816e91224