### PR TITLE
Ensure ROCm BF16 headers

### DIFF
--- a/.devops/llama-server-rocm.Dockerfile
+++ b/.devops/llama-server-rocm.Dockerfile
@@ -43,7 +43,7 @@ ENV CXX=/opt/rocm/llvm/bin/clang++
 # Enable cURL
 ENV LLAMA_CURL=1
 RUN apt-get update && \
-    apt-get install -y libcurl4-openssl-dev curl
+    apt-get install -y libcurl4-openssl-dev curl libamdhip64-dev
 
 RUN make -j$(nproc) llama-server
 


### PR DESCRIPTION
## Summary
- ensure ROCm Docker build installs `libamdhip64-dev` so bfloat16 headers are available

## Testing
- `pre-commit run --files .devops/llama-server-rocm.Dockerfile` *(fails: flake8-no-print requires flake8 4.0.1)*

------
https://chatgpt.com/codex/tasks/task_b_688dd72081a083259856e63e966089cc