### PR TITLE
Guard hip bf16 include for ROCm

### DIFF
--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -3,7 +3,12 @@
 #include <hip/hip_runtime.h>
 #include <hipblas/hipblas.h>
 #include <hip/hip_fp16.h>
+#if !defined(__has_include)
+#define __has_include(x) 0
+#endif
+#if __has_include(<hip/amd_detail/amd_hip_bf16.h>)
 #include <hip/hip_bf16.h>
+#endif
 #ifdef __HIP_PLATFORM_AMD__
 // for rocblas_initialize()
 #include "rocblas/rocblas.h"


### PR DESCRIPTION
## Summary
- check for amd_hip_bf16.h before including hip_bf16.h to avoid missing header build failure on ROCm

## Testing
- `SKIP=flake8 pre-commit run --files ggml/src/ggml-cuda/vendors/hip.h`
- `cmake -S . -B build`
- `cmake --build build -j 2`


------
https://chatgpt.com/codex/tasks/task_b_688ef6d189fc83259cabdf198bb9e0f1