### PR TITLE
Fix CUDA Docker build pip install on Ubuntu 24.04

### DIFF
--- a/.devops/full-cuda.Dockerfile
+++ b/.devops/full-cuda.Dockerfile
@@ -17,8 +17,10 @@ RUN apt-get update && \
 COPY requirements.txt   requirements.txt
 COPY requirements       requirements
 
-RUN pip install --upgrade pip setuptools wheel \
-    && pip install -r requirements.txt
+# Allow installing Python packages into the system environment even though
+# the base image marks it as externally managed (PEP 668).
+RUN python3 -m pip install --upgrade --break-system-packages pip setuptools wheel \
+    && python3 -m pip install --break-system-packages -r requirements.txt
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- allow pip install in CUDA Dockerfile when using Ubuntu 24.04's externally managed Python

## Testing
- `docker build -f /tmp/test.Dockerfile /tmp` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_b_688f3daf6b2483258e864e488d82f973