### PR TITLE
Fix wheel upgrade in CUDA Docker build

### DIFF
--- a/.devops/full-cuda.Dockerfile
+++ b/.devops/full-cuda.Dockerfile
@@ -19,7 +19,8 @@ COPY requirements       requirements
 
 # Allow installing Python packages into the system environment even though
 # the base image marks it as externally managed (PEP 668).
-RUN python3 -m pip install --upgrade --break-system-packages pip setuptools wheel \
+RUN python3 -m pip install --upgrade --break-system-packages pip setuptools \
+    && python3 -m pip install --break-system-packages --ignore-installed wheel \
     && python3 -m pip install --break-system-packages -r requirements.txt
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- avoid uninstall error by installing wheel with `--ignore-installed` in CUDA build Dockerfile

## Testing
- `pre-commit run --files .devops/full-cuda.Dockerfile` *(fails: dependency conflict installing flake8-no-print with flake8 7.0.0)*
- `docker build -f .devops/full-cuda.Dockerfile --progress=plain .` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688f4003b778832580983ebd29b91e2f