### PR TITLE
fix: allow pip upgrade in cuda dockerfile

### DIFF
--- a/.devops/full-cuda.Dockerfile
+++ b/.devops/full-cuda.Dockerfile
@@ -19,7 +19,7 @@ COPY requirements       requirements
 
 # Allow installing Python packages into the system environment even though
 # the base image marks it as externally managed (PEP 668).
-RUN python3 -m pip install --upgrade --break-system-packages pip setuptools \
+RUN python3 -m pip install --break-system-packages --ignore-installed pip setuptools \
     && python3 -m pip install --break-system-packages --ignore-installed wheel \
     && python3 -m pip install --break-system-packages -r requirements.txt
 


### PR DESCRIPTION
## Summary
- let pip ignore existing Debian install in CUDA Dockerfile

## Testing
- `SKIP=flake8 python3 -m pre_commit run --files .devops/full-cuda.Dockerfile`

------
https://chatgpt.com/codex/tasks/task_b_688f42f75e308325b573ded66ca38832