### PR TITLE
Use ccache in cuda-full build

### DIFF
--- a/.devops/full-cuda.Dockerfile
+++ b/.devops/full-cuda.Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.5
 ARG UBUNTU_VERSION=24.04
 
 # This needs to generally match the container host's environment.
@@ -12,7 +13,7 @@ FROM ${BASE_CUDA_DEV_CONTAINER} AS build
 ARG CUDA_DOCKER_ARCH=all
 
 RUN apt-get update && \
-    apt-get install -y build-essential python3 python3-pip git libcurl4-openssl-dev libgomp1
+    apt-get install -y build-essential python3 python3-pip git libcurl4-openssl-dev libgomp1 ccache
 
 COPY requirements.txt   requirements.txt
 COPY requirements       requirements
@@ -33,7 +34,10 @@ ENV CUDA_DOCKER_ARCH=${CUDA_DOCKER_ARCH}
 ENV GGML_CUDA=1
 # Enable cURL
 ENV LLAMA_CURL=1
+# ccache configuration
+ENV CCACHE_DIR=/root/.cache/ccache
+ENV PATH=/usr/lib/ccache:$PATH
 
-RUN make -j$(nproc)
+RUN --mount=type=cache,target=/root/.cache/ccache make -j$(nproc)
 
 ENTRYPOINT ["/app/.devops/tools.sh"]

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   packages: write
 
+env:
+  DOCKER_BUILDKIT: 1
+
 jobs:
   build-base:
     runs-on: ubuntu-latest
@@ -37,6 +40,8 @@ jobs:
           file: ${{ matrix.dockerfile }}
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ matrix.tag }}
+          cache-from: type=gha,scope=${{ matrix.tag }}
+          cache-to: type=gha,scope=${{ matrix.tag }},mode=max
 
   build:
     runs-on: ubuntu-latest
@@ -73,4 +78,6 @@ jobs:
           file: ${{ matrix.dockerfile }}
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ matrix.tag }}
+          cache-from: type=gha,scope=${{ matrix.tag }}
+          cache-to: type=gha,scope=${{ matrix.tag }},mode=max
           build-args: ${{ matrix.build-args }}


### PR DESCRIPTION
## Summary
- speed up full-cuda Docker builds by installing and configuring ccache
- enable BuildKit cache mount for the compilation step
- add GitHub Actions caching to reuse ccache across builds

## Testing
- `pre-commit run --files .github/workflows/docker-publish.yml` *(fails: Cannot install flake8 7.0.0... due to dependency conflict)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688f6268632c8325b44770144a015117