### PR TITLE
Use large code model for 64-bit builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,11 @@ if (NOT MSVC)
     endif()
 endif()
 
+# Ensure large code model for 64-bit x86 builds to handle large static tables
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "amd64")
+    add_compile_options(-mcmodel=large)
+endif()
+
 #
 # build the library
 #

--- a/Makefile
+++ b/Makefile
@@ -435,13 +435,13 @@ endif
 ifndef RISCV
 
 ifeq ($(UNAME_M),$(filter $(UNAME_M),x86_64 i686 amd64))
-	# Use all CPU extensions that are available:
-	MK_CFLAGS     += -march=native -mtune=native
-	HOST_CXXFLAGS += -march=native -mtune=native
+        # Use all CPU extensions that are available:
+        MK_CFLAGS     += -march=native -mtune=native -mcmodel=large
+        HOST_CXXFLAGS += -march=native -mtune=native -mcmodel=large
 
-	# Usage AVX-only
-	#MK_CFLAGS   += -mfma -mf16c -mavx
-	#MK_CXXFLAGS += -mfma -mf16c -mavx
+        # Usage AVX-only
+        #MK_CFLAGS   += -mfma -mf16c -mavx
+        #MK_CXXFLAGS += -mfma -mf16c -mavx
 
 	# Usage SSSE3-only (Not is SSE3!)
 	#MK_CFLAGS   += -mssse3


### PR DESCRIPTION
## Summary
- enable `-mcmodel=large` for 64-bit x86 builds in Makefile
- add `-mcmodel=large` compile option in CMake for x86_64/amd64

## Testing
- `pre-commit run --files Makefile CMakeLists.txt` *(fails: dependency conflict for flake8-no-print)*
- `make llama-quantize`


------
https://chatgpt.com/codex/tasks/task_b_688fa10610788325833457d1652f1bba