### PR TITLE
Disable linker relaxation for CUDA builds

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -379,6 +379,11 @@ if (GGML_CUDA)
             list(APPEND GGML_SOURCES_CUDA ${SRCS})
         endif()
 
+        set(GGML_CUDA_NO_RELAX_SRCS ggml-cuda.cu)
+        foreach(SRC ${GGML_CUDA_NO_RELAX_SRCS})
+            set_source_files_properties(${SRC} PROPERTIES COMPILE_OPTIONS "-Xnvlink=--no-relax")
+        endforeach()
+
         list(APPEND GGML_CDEF_PUBLIC GGML_USE_CUDA)
 
         add_compile_definitions(GGML_CUDA_DMMV_X=${GGML_CUDA_DMMV_X})


### PR DESCRIPTION
## Summary
- apply `-Xnvlink=--no-relax` only to CUDA sources that require it to prevent GOTPCREL relocation failures

## Testing
- `cmake -S ggml -B build.ggml -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=52 -DGGML_BUILD_TESTS=OFF -DGGML_BUILD_EXAMPLES=OFF` *(fails: CUDA not found; get_flags error; ggml.pc.in missing)*

------
https://chatgpt.com/codex/tasks/task_b_68903c5d2bd48325b8126ab58c282236