### PR TITLE
Use mold linker in full-cuda Docker build

### DIFF
--- a/.devops/full-cuda.Dockerfile
+++ b/.devops/full-cuda.Dockerfile
@@ -13,7 +13,9 @@ FROM ${BASE_CUDA_DEV_CONTAINER} AS build
 ARG CUDA_DOCKER_ARCH=all
 
 RUN apt-get update && \
-    apt-get install -y build-essential python3 python3-pip git libcurl4-openssl-dev libgomp1
+    apt-get install -y build-essential python3 python3-pip git libcurl4-openssl-dev libgomp1 mold && \
+    update-alternatives --install /usr/bin/ld ld /usr/bin/mold 100 && \
+    update-alternatives --set ld /usr/bin/mold
 
 COPY requirements.txt   requirements.txt
 COPY requirements       requirements


### PR DESCRIPTION
## Summary
- Install and configure mold linker in full-cuda Docker image

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689071d68ebc83259047bdc5c9e7d4d7