### PR TITLE
Fix mold linking by disabling PIE and relaxation on Linux x86_64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,10 @@ endif()
 # Ensure large code model for 64-bit x86 builds to handle large static tables
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "amd64")
     add_compile_options(-mcmodel=large)
+    if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        add_compile_options(-fno-pie)
+        add_link_options(-no-pie -Wl,--no-relax)
+    endif()
 endif()
 
 #


### PR DESCRIPTION
## Summary
- disable PIE and linker relaxation for Linux x86_64 builds to prevent relocation overflow with mold

## Testing
- `cmake -S . -B build -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_SERVER=OFF -DBUILD_SHARED_LIBS=OFF`
- `cmake --build build -j $(nproc)`

------
https://chatgpt.com/codex/tasks/task_b_689099216af4832595f05ee0569d2623