### PR TITLE
Add no-relax linker flag for CUDA builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -631,9 +631,10 @@ ifdef GGML_CUDA
 			CUDA_PATH ?= /usr/local/cuda
 		endif
 
-		MK_CPPFLAGS  += -DGGML_USE_CUDA -I$(CUDA_PATH)/include -I$(CUDA_PATH)/targets/$(UNAME_M)-linux/include -DGGML_CUDA_USE_GRAPHS
-		MK_LDFLAGS   += -lcuda -lcublas -lculibos -lcudart -lcublasLt -lpthread -ldl -lrt -L$(CUDA_PATH)/lib64 -L/usr/lib64 -L$(CUDA_PATH)/targets/$(UNAME_M)-linux/lib -L$(CUDA_PATH)/lib64/stubs -L/usr/lib/wsl/lib
-		MK_NVCCFLAGS += -use_fast_math
+                MK_CPPFLAGS  += -DGGML_USE_CUDA -I$(CUDA_PATH)/include -I$(CUDA_PATH)/targets/$(UNAME_M)-linux/include -DGGML_CUDA_USE_GRAPHS
+                MK_LDFLAGS   += -lcuda -lcublas -lculibos -lcudart -lcublasLt -lpthread -ldl -lrt -L$(CUDA_PATH)/lib64 -L/usr/lib64 -L$(CUDA_PATH)/targets/$(UNAME_M)-linux/lib -L$(CUDA_PATH)/lib64/stubs -L/usr/lib/wsl/lib
+                MK_LDFLAGS   += -Wl,--no-relax
+                MK_NVCCFLAGS += -use_fast_math
 	endif # GGML_MUSA
 
 	OBJ_GGML += ggml/src/ggml-cuda.o


### PR DESCRIPTION
## Summary
- prevent CUDA link failures by adding `-Wl,--no-relax` to linker flags

## Testing
- `pre-commit run --files Makefile` *(fails: Cannot install flake8 due to flake8-no-print dependency conflict)*
- `GGML_CUDA=1 make llama-quantize-stats -n` *(fails: nvcc not found, but shows `-Wl,--no-relax` in LDFLAGS)*

------
https://chatgpt.com/codex/tasks/task_b_689071e660cc8325b8cad4a223e72e7f